### PR TITLE
fix: roast-me not working in some countries

### DIFF
--- a/src/roast-me/components/audio-overlay.tsx
+++ b/src/roast-me/components/audio-overlay.tsx
@@ -116,55 +116,65 @@ export function AudioOverlay({
   const MicIcon = isListening ? Mic : MicOff;
 
   return (
-    <button
-      onClick={onToggle}
-      disabled={status === "connecting"}
-      className={cn(
-        "absolute right-8 top-8 text-sm flex items-center gap-2 rounded-md bg-black/50 px-3 py-2 font-semibold text-white backdrop-blur-sm transition-all cursor-pointer hover:bg-black/70 disabled:cursor-not-allowed disabled:opacity-70",
-        isPulsing && "animate-micPulse",
-      )}
-    >
-      {status === "connecting" && (
-        <>
-          <Loader2 className="h-4 w-4 animate-spin" />
-          <span>Connecting...</span>
-        </>
-      )}
+    <div className="absolute right-8 top-8 flex flex-col items-end gap-2">
+      <button
+        onClick={onToggle}
+        disabled={status === "connecting"}
+        className={cn(
+          "text-sm flex items-center gap-2 rounded-md bg-black/50 px-3 py-2 font-semibold text-white backdrop-blur-sm transition-all cursor-pointer hover:bg-black/70 disabled:cursor-not-allowed disabled:opacity-70",
+          isPulsing && "animate-micPulse",
+        )}
+      >
+        {status === "connecting" && (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Connecting...</span>
+          </>
+        )}
 
-      {status === "listening" && (
-        <>
-          <div className="relative flex items-center justify-center">
-            <MicIcon
-              className={cn(
-                "h-4 w-4",
-                isListening ? "text-white" : "text-warning",
-              )}
-            />
-          </div>
-          <div className="flex gap-1">
-            {Array.from({ length: BAR_COUNT }).map((_, i) => (
-              <div
-                key={i}
+        {status === "listening" && (
+          <>
+            <div className="relative flex items-center justify-center">
+              <MicIcon
                 className={cn(
-                  "w-2 h-5 rounded-sm transition-colors duration-100",
-                  isListening
-                    ? i < activeBars
-                      ? "bg-white"
-                      : "bg-white/30"
-                    : "bg-warning",
+                  "h-4 w-4",
+                  isListening ? "text-white" : "text-warning",
                 )}
               />
-            ))}
-          </div>
-        </>
-      )}
+            </div>
+            <div className="flex gap-1">
+              {Array.from({ length: BAR_COUNT }).map((_, i) => (
+                <div
+                  key={i}
+                  className={cn(
+                    "w-2 h-5 rounded-sm transition-colors duration-100",
+                    isListening
+                      ? i < activeBars
+                        ? "bg-white"
+                        : "bg-white/30"
+                      : "bg-warning",
+                  )}
+                />
+              ))}
+            </div>
+          </>
+        )}
+
+        {status === "error" && (
+          <>
+            <MicOff className="h-4 w-4 text-destructive" />
+            <span className="text-destructive">Error</span>
+          </>
+        )}
+      </button>
 
       {status === "error" && (
-        <>
-          <MicOff className="h-4 w-4 text-destructive" />
-          <span className="text-destructive">Error</span>
-        </>
+        <p className="max-w-[16rem] rounded-md bg-black/50 px-3 py-2 text-right text-xs font-medium text-white backdrop-blur-sm">
+          We couldn&apos;t connect to the voice service. It may not work on a
+          VPN or in some countries. If you&apos;re on a VPN, turn it off and try
+          again.
+        </p>
       )}
-    </button>
+    </div>
   );
 }

--- a/src/roast-me/components/audio-overlay.tsx
+++ b/src/roast-me/components/audio-overlay.tsx
@@ -169,7 +169,7 @@ export function AudioOverlay({
       </button>
 
       {status === "error" && (
-        <p className="max-w-[16rem] rounded-md bg-black/50 px-3 py-2 text-right text-xs font-medium text-white backdrop-blur-sm">
+        <p className="max-w-[16rem] rounded-md bg-black/50 px-3 py-2 text-left text-xs font-medium text-white backdrop-blur-sm">
           We couldn&apos;t connect to the voice service. It may not work on a
           VPN or in some countries. If you&apos;re on a VPN, turn it off and try
           again.

--- a/src/roast-me/components/message-chat.tsx
+++ b/src/roast-me/components/message-chat.tsx
@@ -87,10 +87,15 @@ export function MessageChat({
     };
   }, [showResults, data, isStatic]);
 
-  // Show initial message after a short delay when transcription is listening
+  // Show initial message after a short delay once transcription settles —
+  // either it's listening (say it aloud) or it errored out (click instead).
   useEffect(() => {
     if (isStatic) return;
-    if (transcriptionStatus === "listening" && !showInitialMessage) {
+    if (
+      (transcriptionStatus === "listening" ||
+        transcriptionStatus === "error") &&
+      !showInitialMessage
+    ) {
       const timer = setTimeout(() => {
         setShowInitialMessage(true);
       }, 500);
@@ -112,19 +117,36 @@ export function MessageChat({
     <>
       {(showInitialMessage || cameraStatus === "frozen" || isStatic) && (
         <MessageBox side="left" disabledSound={isStatic}>
-          Hey! Say &quot;
-          {isStatic ? (
-            "Roast me"
+          {transcriptionStatus === "error" && !isStatic ? (
+            <>
+              Voice isn&apos;t available right now, but you can still get
+              roasted — just click{" "}
+              <button
+                onClick={onRoast}
+                disabled={cameraStatus === "frozen"}
+                className="link cursor-pointer"
+              >
+                Roast me
+              </button>
+              .
+            </>
           ) : (
-            <button
-              onClick={onRoast}
-              disabled={cameraStatus === "frozen"}
-              className="link cursor-pointer"
-            >
-              Roast me
-            </button>
+            <>
+              Hey! Say &quot;
+              {isStatic ? (
+                "Roast me"
+              ) : (
+                <button
+                  onClick={onRoast}
+                  disabled={cameraStatus === "frozen"}
+                  className="link cursor-pointer"
+                >
+                  Roast me
+                </button>
+              )}
+              &quot; aloud.
+            </>
           )}
-          &quot; aloud.
         </MessageBox>
       )}
       {mispronunciation &&

--- a/src/roast-me/hooks/use-realtime-transcription.ts
+++ b/src/roast-me/hooks/use-realtime-transcription.ts
@@ -174,7 +174,7 @@ export function useRealtimeTranscription({
 
       if (!tokenResponse.ok) {
         const errorText = await tokenResponse.text();
-        console.error("Failed to get realtime token:", errorText);
+        console.warn("Failed to get realtime token:", errorText);
         throw new Error("Failed to get realtime token");
       }
 
@@ -224,8 +224,7 @@ export function useRealtimeTranscription({
       };
 
       ws.onerror = (error) => {
-        console.error("WebSocket error:", error);
-        console.error("WebSocket readyState:", ws.readyState);
+        console.warn("WebSocket error:", error, "readyState:", ws.readyState);
         posthog.capture("roast_me_voice_connection_error", {
           mode,
           ready_state: ws.readyState,
@@ -242,7 +241,8 @@ export function useRealtimeTranscription({
         cleanup();
       };
     } catch (error) {
-      console.error("Error connecting to realtime API:", error);
+      // Connection to OpenAI failed (often geo-block) — expected, warn only.
+      console.warn("Error connecting to realtime API:", error);
       setStatus("error");
       cleanup();
     }


### PR DESCRIPTION
When the voice transcription WebSocket can't connect (geo-blocked countries, blocked VPN IPs), roast-me now degrades gracefully instead of dead-ending on a red "Error"

- Shows an error badge + a tooltip explaining the likely cause (VPN / unsupported country).
- Surfaces the "Roast me" button in the error state so users can still trigger the roast by clicking instead of speaking.
- Treats connection failures as expected (`console.warn`, not `console.error`), so they no longer trip the Next dev error overlay. Telemetry is unchanged (still captured in PostHog).



<img width="809" height="209" alt="Screenshot 2026-07-11 at 8 29 32 PM" src="https://github.com/user-attachments/assets/3416e102-2427-4c34-b787-7080001477d0" />
