### PR TITLE
  fix: route resume grading through AI Gateway to stop false "future dates" flag (SIL-3430)

### DIFF
--- a/src/pages/api/grade.ts
+++ b/src/pages/api/grade.ts
@@ -5,7 +5,6 @@ import {
   ResponseSchema,
   sanitizeCompletion,
 } from "@/resume-checker/prompts/grade";
-import { google } from "@ai-sdk/google";
 import { generateObject } from "ai";
 import type { NextApiRequest, NextApiResponse } from "next";
 import pdf from "pdf-parse";
@@ -54,7 +53,7 @@ export default async function handler(
     const parsed = await pdf(pdfBuffer);
 
     const completion = await generateObject({
-      model: google("gemini-2.5-flash"),
+      model: "google/gemini-2.5-flash",
       temperature: 0,
       messages: messages(parsed, pdfBuffer),
       schema: ResponseSchema,


### PR DESCRIPTION
gemini-2.5-flash flags past dates ("Oct 2024 - Present", "09.2024 - Presente") as being "in the future". It correlates 1:1 with grade C and **drags excellent resumes down from S to C** with a false accusation.

It depends on the **serving backend**, not the prompt. The same model served via `google()` direct (Google AI Studio, what prod uses) hallucinates; served via the Vercel AI Gateway, it does not.

