### PR TITLE
fix(api): send emails from verified notifications.silver.dev domain

### DIFF
--- a/src/app/roast-me/api/feedback/route.ts
+++ b/src/app/roast-me/api/feedback/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest) {
       : null;
 
     const { error } = await resend.emails.send({
-      from: "Roast Me <feedback@send.silver.dev>",
+      from: "Roast Me <feedback@notifications.silver.dev>",
       to: ["engineering@silver.dev"],
       subject: "User feedback",
       attachments: base64Data

--- a/src/pages/api/feedback-take-home-checker.ts
+++ b/src/pages/api/feedback-take-home-checker.ts
@@ -35,7 +35,7 @@ export default async function handler(
 `;
 
     const { error } = await resend.emails.send({
-      from: "Take-home Checker <feedback@send.silver.dev>",
+      from: "Take-home Checker <feedback@notifications.silver.dev>",
       to: ["engineering@silver.dev"],
       subject: "User feedback",
       html,

--- a/src/pages/api/feedback.ts
+++ b/src/pages/api/feedback.ts
@@ -45,7 +45,7 @@ export default async function handler(
     }
 
     const { error } = await resend.emails.send({
-      from: "Resume Checker <feedback@send.silver.dev>",
+      from: "Resume Checker <feedback@notifications.silver.dev>",
       to: ["engineering@silver.dev"],
       subject: "Resume Checker",
       react: FeedbackEmail({ yellow_flags, red_flags, grade, description }),
@@ -60,7 +60,7 @@ export default async function handler(
   } catch (err) {
     console.error(err);
     res.status(500).send({
-      message: "Tuvimos un error inesperado al enviar tu mail, probá denuevo",
+      message: "Tuvimos un error inesperado al enviar tu mail, probá una vez más",
     });
   }
 }

--- a/src/pages/api/submit-invoice.ts
+++ b/src/pages/api/submit-invoice.ts
@@ -78,7 +78,7 @@ export default async function handler(
         : `SilverEd Course Invoice - ${invoiceData.silveredCourse}`;
 
     const { error } = await resend.emails.send({
-      from: "Invoice Generator <invoices@send.silver.dev>",
+      from: "Invoice Generator <invoices@notifications.silver.dev>",
       to: ["silver-dev@ap.mercury.com"],
       subject: emailSubject,
       react: InvoiceEmail({


### PR DESCRIPTION
## Summary
- Resend was rejecting all feedback/invoice emails with `The send.silver.dev domain is not verified`. The DNS records in the silver.dev zone (`resend._domainkey.notifications`, `send.notifications` MX/TXT, `links.notifications` CNAME) show the verified Resend domain is **notifications.silver.dev** — the `send.` subdomain is only Resend's return-path/bounce setup, not a sending domain.
- Updated all four `from` addresses (resume checker, take-home checker, roast me, invoice generator) from `@send.silver.dev` to `@notifications.silver.dev`.
- Reworded the resume-checker error message: "probá denuevo" → "probá una vez más".

## Test plan
- [ ] Submit feedback on resume-checker in production/preview and confirm the email arrives at engineering@silver.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSxWLvUkZcnEKiUccfkJWv