### PR TITLE
fix(api): stop leaking raw provider errors in take-home checker

### DIFF
--- a/src/pages/api/analyze-take-home.ts
+++ b/src/pages/api/analyze-take-home.ts
@@ -54,15 +54,17 @@ export default async function handler(
         }));
       takeHome = { code, docs };
     } else {
-      throw new Error("Either GitHub repo or zip file is required");
+      return res.status(400).send("Either GitHub repo or zip file is required");
     }
 
     if (!takeHome.docs) {
-      throw new Error(
-        "It's mandatory for your take-home to have a README.md explaining it.",
-      );
+      return res
+        .status(400)
+        .send(
+          "It's mandatory for your take-home to have a README.md explaining it.",
+        );
     }
-    if (!takeHome.code) throw new Error("Repo is empty.");
+    if (!takeHome.code) return res.status(400).send("Repo is empty.");
 
     const analysis = await analyzeTakeHome(takeHome);
 
@@ -78,9 +80,12 @@ export default async function handler(
 
     res.status(200).json(data);
   } catch (error) {
+    console.error(error);
     res
       .status(500)
-      .send(error instanceof Error ? error.message : "Unknown error");
+      .send(
+        "Something went wrong on our end while analyzing your take-home. Please try again in a few minutes.",
+      );
   }
 }
 


### PR DESCRIPTION
## Problem

A candidate hit this in the take-home checker UI, rendered verbatim on screen:

> A positive credit balance is required for all requests, including BYOK, so fallback providers remain available. Add credits at https://vercel.com/... to continue.

`/api/analyze-take-home` sent `error.message` raw to the client, and the client renders it as-is, so any provider/infra failure (AI Gateway billing, rate limits, outages) leaked internals directly to candidates.

## Fix

Single file, `src/pages/api/analyze-take-home.ts`:

- Intentional validation errors (missing repo/zip, missing README, empty repo) now return 400 directly with their message instead of throwing.
- The catch only handles unexpected errors: full error is logged (`console.error` → Vercel function logs) and the client gets a generic "Something went wrong on our end..." with a 500.

