### PR TITLE
fix(api): harden /api/analysis with graceful failures and structured logging

### DIFF
--- a/src/behavioral-checker/client-assistance/core/actions/ConsultByAudio.ts
+++ b/src/behavioral-checker/client-assistance/core/actions/ConsultByAudio.ts
@@ -1,4 +1,5 @@
 import { Question } from "@/behavioral-checker/data/questions";
+import type { ApiLogger } from "@/lib/structured-logger";
 import { AssistanceResponse } from "../domain/Action";
 import {
   clientAssistanceService,
@@ -15,7 +16,8 @@ class ConsultByAudio {
   async invoke(
     id: Question["id"],
     question: string,
-    audioPath: string
+    audioPath: string,
+    logger?: ApiLogger
   ): Promise<AssistanceResponse> {
     console.log("Consulting by audio:", audioPath);
     console.time("Transcribe Audio");
@@ -25,7 +27,8 @@ class ConsultByAudio {
     const response = await this.clientAssistanceService.consultByText(
       id,
       question,
-      content
+      content,
+      logger
     );
     console.timeEnd("Consult By Text");
 

--- a/src/behavioral-checker/client-assistance/core/domain/ClientAssitanceService.ts
+++ b/src/behavioral-checker/client-assistance/core/domain/ClientAssitanceService.ts
@@ -1,5 +1,9 @@
 import { Question } from "@/behavioral-checker/data/questions";
-import { getPromptExamples } from "@/behavioral-checker/notion/database";
+import {
+  getPromptExamples,
+  NotionOperationError,
+} from "@/behavioral-checker/notion/database";
+import type { ApiLogger } from "@/lib/structured-logger";
 import { AssistanceResponse } from "./Action";
 import { aiClient, AIClient } from "./AIClient";
 
@@ -9,9 +13,21 @@ export class ClientAssistanceService {
   async consultByText(
     questionId: Question["id"],
     question: string,
-    response: string
+    response: string,
+    logger?: ApiLogger
   ): Promise<AssistanceResponse> {
-    const exampleResponses = await getPromptExamples(questionId);
+    let exampleResponses: { response: string; score: string }[] = [];
+    try {
+      exampleResponses = await getPromptExamples(questionId);
+    } catch (error) {
+      console.error("Proceeding without prompt examples:", error);
+      logger?.setContext({
+        "notion.operation": "getPromptExamples",
+        "notion.timed_out":
+          error instanceof NotionOperationError && error.timedOut,
+        "notion.degraded_read": true,
+      });
+    }
     return await this.aiClient.consult(
       questionId,
       question,

--- a/src/behavioral-checker/client-assistance/infrastructure/OpenAISdkAIClient.ts
+++ b/src/behavioral-checker/client-assistance/infrastructure/OpenAISdkAIClient.ts
@@ -1,8 +1,16 @@
 import { Question } from "@/behavioral-checker/data/questions";
+import { extractJsonFromString } from "@/lib/utils";
 import OpenAI from "openai";
 import { ChatCompletionSystemMessageParam } from "openai/resources/index.mjs";
 import { AIClient } from "../core/domain/AIClient";
 import { AssistanceResponse } from "../core/domain/Action";
+
+export class InvalidModelResponseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidModelResponseError";
+  }
+}
 
 export class OpenAISdkAIClient implements AIClient {
   private client: OpenAI;
@@ -19,31 +27,53 @@ export class OpenAISdkAIClient implements AIClient {
     response: string,
     exampleResponses: { response: string; score: string }[]
   ): Promise<AssistanceResponse> {
-    try {
-      const message = this.getInitialMessage(
-        question,
-        response,
-        exampleResponses
+    const message = this.getInitialMessage(
+      question,
+      response,
+      exampleResponses
+    );
+    const res = await this.client.chat.completions.create({
+      model: "gpt-4o",
+      messages: [message],
+      max_tokens: 1000,
+      response_format: { type: "json_object" },
+    });
+
+    const choice = res.choices[0];
+    const assistantMessage = choice.message.content || "";
+
+    if (choice.finish_reason === "length") {
+      throw new InvalidModelResponseError(
+        "Model response truncated at max_tokens"
       );
-      const res = await this.client.chat.completions.create({
-        model: "gpt-4o",
-        messages: [message],
-        max_tokens: 300,
-      });
-
-      const assistantMessage = res.choices[0].message.content || "";
-
-      return {
-        ...JSON.parse(
-          assistantMessage.replace("```json", "").replace("```", "")
-        ),
-        question,
-        questionId,
-        response,
-      };
-    } catch (error: unknown) {
-      throw error;
     }
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(assistantMessage);
+    } catch {
+      try {
+        parsed = extractJsonFromString(assistantMessage) as Record<
+          string,
+          unknown
+        >;
+      } catch {
+        throw new InvalidModelResponseError("Model response is not valid JSON");
+      }
+    }
+
+    if (typeof parsed.result !== "string") {
+      throw new InvalidModelResponseError(
+        "Model response missing result field"
+      );
+    }
+
+    return {
+      ...parsed,
+      question,
+      questionId,
+      response,
+    } as AssistanceResponse;
   }
 
   private getInitialMessage(

--- a/src/behavioral-checker/notion/database.ts
+++ b/src/behavioral-checker/notion/database.ts
@@ -3,12 +3,29 @@ import {
   Result,
 } from "@/behavioral-checker/client-assistance/core/domain/Action";
 import { Question } from "@/behavioral-checker/data/questions";
-import { Client } from "@notionhq/client";
+import { Client, RequestTimeoutError } from "@notionhq/client";
 import { PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 
-const notion = new Client({ auth: process.env.NOTION_API_KEY });
+const NOTION_TIMEOUT_MS = 5_000;
+
+const notion = new Client({
+  auth: process.env.NOTION_API_KEY,
+  timeoutMs: NOTION_TIMEOUT_MS,
+});
 
 const DATABASE_ID = process.env.NOTION_DATABASE_ID as string;
+
+export class NotionOperationError extends Error {
+  constructor(
+    message: string,
+    public readonly operation: string,
+    public readonly timedOut: boolean,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "NotionOperationError";
+  }
+}
 
 export const addFeedbackToNotion = async (
   data: AssistanceResponse & { feedbackScore?: string; feedbackText?: string }
@@ -44,7 +61,12 @@ export const addFeedbackToNotion = async (
     return res.id;
   } catch (error: any) {
     console.error("Error añadiendo registro:", error.message);
-    throw new Error("Failed to add feedback to Notion");
+    throw new NotionOperationError(
+      "Failed to add feedback to Notion",
+      "addFeedbackToNotion",
+      RequestTimeoutError.isRequestTimeoutError(error),
+      error
+    );
   }
 };
 
@@ -97,7 +119,12 @@ export const getPromptExamples = async (questionId: Question["id"]) => {
     });
   } catch (error: any) {
     console.error("Error al obtener respuestas:", error.message);
-    throw new Error("Failed to fetch feedback from Notion");
+    throw new NotionOperationError(
+      "Failed to fetch feedback from Notion",
+      "getPromptExamples",
+      RequestTimeoutError.isRequestTimeoutError(error),
+      error
+    );
   }
 };
 
@@ -167,7 +194,12 @@ export const getLastFeedback = async (
     };
   } catch (error: any) {
     console.error("Error al obtener respuestas:", error.message);
-    throw new Error("Failed to fetch feedback from Notion");
+    throw new NotionOperationError(
+      "Failed to fetch feedback from Notion",
+      "getLastFeedback",
+      RequestTimeoutError.isRequestTimeoutError(error),
+      error
+    );
   }
 };
 
@@ -188,6 +220,11 @@ export const updateFeedbackInNotion = async (
     console.log("Registro actualizado:", pageId);
   } catch (error: any) {
     console.error("Error actualizando registro:", error.message);
-    throw new Error("Failed to update feedback in Notion");
+    throw new NotionOperationError(
+      "Failed to update feedback in Notion",
+      "updateFeedbackInNotion",
+      RequestTimeoutError.isRequestTimeoutError(error),
+      error
+    );
   }
 };

--- a/src/lib/structured-logger.ts
+++ b/src/lib/structured-logger.ts
@@ -1,0 +1,95 @@
+// Dependency-free structured logger. Emits one JSON row per invocation.
+// Adapted from candidate-portal/utils/structured-logger.ts.
+// Field names follow OTel semantic conventions (http.route, error.type, ...);
+// interim solution until we adopt @vercel/otel.
+
+export type LogContext = Record<string, unknown>;
+
+export type LoggerSink = (level: string, data: string) => void;
+
+const consoleSink: LoggerSink = (level, data) => {
+  if (level === "error") console.error(data);
+  else if (level === "warn") console.warn(data);
+  else console.info(data);
+};
+
+const REDACTED = new Set([
+  "headers",
+  "cookies",
+  "authorization",
+  "sql",
+  "query",
+  "params",
+  "env",
+  "secret",
+  "token",
+  "password",
+  "key",
+] as const);
+
+interface ErrorFields {
+  errorType?: string;
+  errorMessage?: string;
+}
+
+export function createApiLogger(
+  route: string,
+  method: string,
+  functionName: string,
+  sink?: LoggerSink,
+) {
+  const startTime = Date.now();
+  let context: Partial<LogContext> = {};
+  const errorFields: ErrorFields = {};
+  let emitted = false;
+
+  return {
+    setContext(fields: Partial<LogContext>) {
+      const sanitizedFields = { ...fields };
+      for (const key of REDACTED) {
+        delete sanitizedFields[key];
+      }
+      context = { ...context, ...sanitizedFields };
+    },
+
+    error(err: unknown) {
+      if (err instanceof Error) {
+        errorFields.errorType = err.name;
+        errorFields.errorMessage = err.message;
+      } else if (typeof err === "string") {
+        errorFields.errorType = "string";
+        errorFields.errorMessage = err;
+      } else if (err !== null && err !== undefined) {
+        errorFields.errorType = "unknown";
+        errorFields.errorMessage = JSON.stringify(err);
+      }
+    },
+
+    emit(): string {
+      if (emitted) return "";
+      emitted = true;
+
+      const logRow: Record<string, unknown> = {
+        timestamp: new Date().toISOString(),
+        level: Object.keys(errorFields).length > 0 ? "error" : "info",
+        "http.route": route,
+        "http.request.method": method,
+        "code.function.name": functionName,
+        "http.response.status_code": null,
+        outcome: null,
+        durationMs: Date.now() - startTime,
+        ...context,
+        ...(errorFields.errorType !== undefined && {
+          "error.type": errorFields.errorType,
+          "error.message": errorFields.errorMessage,
+        }),
+      };
+
+      const json = JSON.stringify(logRow);
+      (sink ?? consoleSink)(logRow.level as string, json);
+      return json;
+    },
+  };
+}
+
+export type ApiLogger = ReturnType<typeof createApiLogger>;

--- a/src/pages/api/analysis.ts
+++ b/src/pages/api/analysis.ts
@@ -1,5 +1,10 @@
 import { consultByAudio } from "@/behavioral-checker/client-assistance/core/actions/ConsultByAudio";
-import { addFeedbackToNotion } from "@/behavioral-checker/notion/database";
+import { InvalidModelResponseError } from "@/behavioral-checker/client-assistance/infrastructure/OpenAISdkAIClient";
+import {
+  addFeedbackToNotion,
+  NotionOperationError,
+} from "@/behavioral-checker/notion/database";
+import { ApiLogger, createApiLogger } from "@/lib/structured-logger";
 import { promises as fs } from "fs";
 import multer from "multer";
 import { NextApiRequest, NextApiResponse } from "next";
@@ -17,44 +22,92 @@ const storage = multer.diskStorage({
 
 const upload = multer({ storage });
 
-const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  if (req.method !== "POST") {
-    return res.status(405).json({ error: "Method not allowed" });
-  }
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+  logger: ApiLogger
+) => {
+  let status = 500;
+  let outcome = "error";
 
   try {
+    if (req.method !== "POST") {
+      status = 405;
+      outcome = "method_not_allowed";
+      return res.status(405).json({ error: "Method not allowed" });
+    }
+
     const file = (req as any).file;
     if (!file) {
+      status = 400;
+      outcome = "no_file";
       return res.status(400).json({ error: "No file uploaded" });
     }
 
     const filePath = path.join(os.tmpdir(), file.filename);
     const id = req.body.id as string;
     const question = req.body.question as string;
+    logger.setContext({ questionId: id });
 
-    const result = await consultByAudio.invoke(id, question, filePath);
+    const result = await consultByAudio.invoke(id, question, filePath, logger);
 
-    addFeedbackToNotion(result);
-
-    res.status(200).json(result);
-  } catch (error) {
-    console.error("Error processing audio:", error);
-    res.status(500).json({ error: "Error processing audio" });
-  } finally {
-    const tempFilePath = path.join(os.tmpdir(), (req as any).file.filename);
+    let notionPersisted = true;
     try {
-      await fs.unlink(tempFilePath);
+      await addFeedbackToNotion(result);
     } catch (error) {
-      console.error("Error deleting temporary file:", error);
+      notionPersisted = false;
+      logger.error(error);
+      logger.setContext({
+        "notion.operation": "addFeedbackToNotion",
+        "notion.timed_out":
+          error instanceof NotionOperationError && error.timedOut,
+      });
     }
+
+    if (notionPersisted) {
+      status = 200;
+      outcome = "success";
+      res.status(200).json(result);
+    } else {
+      status = 202;
+      outcome = "notion_write_failed";
+      res.status(202).json({ ...result, notionPersisted: false });
+    }
+  } catch (error) {
+    logger.error(error);
+    if (error instanceof InvalidModelResponseError) {
+      status = 502;
+      outcome = "invalid_model_response";
+      res.status(502).json({ error: "invalid_model_response" });
+    } else {
+      status = 500;
+      outcome = "error";
+      res.status(500).json({ error: "Error processing audio" });
+    }
+  } finally {
+    const filename = (req as any).file?.filename;
+    if (filename) {
+      try {
+        await fs.unlink(path.join(os.tmpdir(), filename));
+      } catch (error) {
+        console.error("Error deleting temporary file:", error);
+      }
+    }
+    logger.setContext({ "http.response.status_code": status, outcome });
+    logger.emit();
   }
 };
 
 const middleware = upload.single("audio");
-const multerMiddleware = (req: any, res: any, next: any) =>
+const multerMiddleware = (req: any, res: any, logger: ApiLogger, next: any) =>
   middleware(req, res, (err) => {
     if (err) {
-      console.error("Error uploading file:", err);
+      logger.error(err);
+      logger.setContext({
+        "http.response.status_code": 500,
+        outcome: "upload_error",
+      });
+      logger.emit();
       return res.status(500).json({ error: "File upload error" });
     }
     next();
@@ -66,5 +119,11 @@ export const config = {
   },
 };
 
-export default (req: NextApiRequest, res: NextApiResponse) =>
-  multerMiddleware(req, res, () => handler(req, res));
+export default (req: NextApiRequest, res: NextApiResponse) => {
+  const logger = createApiLogger(
+    "/api/analysis",
+    req.method ?? "UNKNOWN",
+    "analysis"
+  );
+  return multerMiddleware(req, res, logger, () => handler(req, res, logger));
+};


### PR DESCRIPTION
## Context

Incident 2026-07-31 04:56–05:16 UTC: `/api/analysis` returned 500s during Notion degradation plus unhandled `SyntaxError`s from JSON parsing.

## Changes

- **Notion**: shared client gets `timeoutMs: 5000` (was 60s default); all four operations throw typed `NotionOperationError` (`operation`, `timedOut`). Error message strings unchanged, so `/api/behavioral-feedback` responses are byte-identical.
- **Feedback write**: the previously floating `addFeedbackToNotion(result)` promise is awaited; on failure the route returns **202 `{...result, notionPersisted: false}`** (UI checks `response.ok`, so 202 still renders) instead of crashing post-response.
- **Prompt examples read** (`getPromptExamples`, awaited in the request path — the likely source of the incident's 500s): degrades to empty examples instead of failing the request.
- **JSON parse root cause**: `response_format: json_object`, `max_tokens` 300→1000 (truncation at the cap is what produced `SyntaxError ... position 275`), `finish_reason` check, `extractJsonFromString` fallback; residual failures return **502 `invalid_model_response`**.
- **New `src/lib/structured-logger.ts`** (copied from candidate-portal `utils/structured-logger.ts`, Vercel-adapted): one JSON row per request, queryable in Dash0 by `http.route`, `http.response.status_code`, `error.type`, `error.message`, `notion.operation`, `notion.timed_out`, `outcome`.
- Fixed a latent `TypeError` in the `finally` block on the no-file 400 path.

> **Note on telemetry**: log field names follow OTel semantic conventions as an interim measure; the plan is to adopt `@vercel/otel` across the app later and retire the hand-rolled logger.

## Verification

- `bun run build` + `bun run lint` pass.
- Dev-server smoke tests: 405, no-file 400, and upstream-failure 500 paths return the expected bodies, each emitting one structured log row; no more `finally` TypeError.
- 200/202/502 paths need real OpenAI/Notion keys (absent locally) — simulations: bogus `NOTION_API_KEY` → 202 `notionPersisted: false`; `timeoutMs: 1` → `notion.timed_out: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ga5Y76XEThv8gTfCDFqFyT