### PR TITLE
Measure the fees calculator as part of the buyer funnel

### DIFF
--- a/src/app/fees-calculator/client.tsx
+++ b/src/app/fees-calculator/client.tsx
@@ -23,9 +23,16 @@ import { cn } from "@/lib/utils";
 import NumberFlow from "@number-flow/react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Bar, BarChart, XAxis, YAxis } from "recharts";
 import posthog from "posthog-js";
+import { captureEvent } from "@/lib/analytics/capture";
+import {
+  AnalyticsEvent,
+  AnalyticsProperty,
+  BookingSurface,
+  PageType,
+} from "@/lib/analytics/events";
 
 type ServiceModel = typeof CONTINGENCY | typeof STAFFING;
 
@@ -161,6 +168,39 @@ export function FeesCalculator() {
     ) as ContractProps,
   );
 
+  // The funnel step this page owns. silver.dev measures a buyer up to the point
+  // they leave for the calculator; these two events are the only view of what
+  // happens once they arrive. Both are ref-guarded rather than state-guarded so
+  // React's double-invoked effects in development cannot inflate the counts.
+  const hasTrackedOpen = useRef(false);
+  const hasTrackedCompletion = useRef(false);
+
+  const funnelProperties = {
+    [AnalyticsProperty.PAGE_TYPE]: PageType.CALCULATOR,
+    [AnalyticsProperty.PAGE_TOPIC]: "fees_calculator",
+  };
+
+  useEffect(() => {
+    if (hasTrackedOpen.current) return;
+    hasTrackedOpen.current = true;
+    // Once per mount: this is arrival, not a response to anything that changes.
+    captureEvent(AnalyticsEvent.FEES_CALCULATOR_OPENED, funnelProperties);
+  }, []);
+
+  /**
+   * Adjusting any term is what "completed" means here.
+   *
+   * The calculator renders a number immediately from its defaults, so a first
+   * result proves nothing — every visitor gets one just by arriving. The signal
+   * worth counting is that someone put *their* terms in and read the estimate
+   * back, which is exactly one call to setContractProp.
+   */
+  function trackCompletion() {
+    if (hasTrackedCompletion.current) return;
+    hasTrackedCompletion.current = true;
+    captureEvent(AnalyticsEvent.FEES_CALCULATOR_COMPLETED, funnelProperties);
+  }
+
   function getParamOrDefault(key: string, defaultValue: any) {
     const value = searchParams?.get(key);
     if (value === null) return defaultValue;
@@ -273,6 +313,7 @@ Link: ${window.location.origin}/${window.location.pathname}?${queryString}`,
   }
 
   function setContractProp(key: keyof ContractProps, value: any) {
+    trackCompletion();
     setContractProps((params) => ({
       ...params,
       [key]: value,
@@ -326,7 +367,23 @@ Link: ${window.location.origin}/${window.location.pathname}?${queryString}`,
             </Link>
           </Button>*/}
           <Button asChild>
-            <Link target="_blank" href="https://silver.dev/companies">
+            {/*
+              silver.dev/companies is a server redirect straight to Calendly, so
+              the booking cannot be recorded once the visitor leaves. This click
+              is the last observable moment, and the only place this particular
+              path into a meeting shows up in the funnel at all.
+            */}
+            <Link
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://silver.dev/companies"
+              onClick={() =>
+                captureEvent(AnalyticsEvent.MEETING_BOOKING_STARTED, {
+                  ...funnelProperties,
+                  [AnalyticsProperty.BOOKING_SURFACE]: BookingSurface.LINK,
+                })
+              }
+            >
               Book with Gabriel
             </Link>
           </Button>

--- a/src/lib/analytics/capture.ts
+++ b/src/lib/analytics/capture.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import posthog from "posthog-js";
+import {
+  AnalyticsEvent,
+  AnalyticsProperties,
+  AnalyticsProperty,
+  UTM_PARAMS,
+} from "./events";
+
+/**
+ * Campaign context for the current URL.
+ *
+ * silver.dev forwards `src` and the UTM keys across the domain boundary when it
+ * redirects `/fees` here, so a buyer arriving from the quote receipt email
+ * carries `?src=quote_receipt`. Reading them here is what keeps that
+ * attribution attached to the events this app sends.
+ */
+export function landingProperties(): AnalyticsProperties {
+  if (typeof window === "undefined") return {};
+
+  const params = new URLSearchParams(window.location.search);
+  const properties: AnalyticsProperties = {};
+
+  const source = params.get("src");
+  if (source) properties[AnalyticsProperty.SOURCE] = source;
+
+  for (const [param, property] of UTM_PARAMS) {
+    const value = params.get(param);
+    if (value) properties[property] = value;
+  }
+
+  if (document.referrer) {
+    properties[AnalyticsProperty.REFERRER] = document.referrer;
+  }
+
+  return properties;
+}
+
+function withoutEmpty(properties: AnalyticsProperties): AnalyticsProperties {
+  return Object.fromEntries(
+    Object.entries(properties).filter(
+      ([, value]) => value !== undefined && value !== null && value !== "",
+    ),
+  ) as AnalyticsProperties;
+}
+
+/**
+ * Send an event, and never let analytics break the page.
+ *
+ * These calls sit in effects and change handlers on the calculator, so every
+ * failure mode — PostHog not loaded, a key missing in a preview build, an ad
+ * blocker killing the request — has to be invisible to the user. The network
+ * leg is already fire-and-forget inside posthog-js; the try/catch covers the
+ * synchronous half.
+ */
+export function captureEvent(
+  event: AnalyticsEvent,
+  properties: AnalyticsProperties = {},
+): void {
+  const payload = withoutEmpty({
+    [AnalyticsProperty.PAGE_PATH]:
+      typeof window === "undefined" ? undefined : window.location.pathname,
+    ...landingProperties(),
+    ...properties,
+  });
+
+  if (process.env.NODE_ENV === "development") {
+    // posthog-js goes quiet when the project key is missing or rejected, which
+    // is the normal state of a local checkout. Logging here shows what would
+    // have been sent, so the funnel can be walked without a live project.
+    console.info(`[analytics] ${event}`, payload);
+  }
+
+  try {
+    posthog.capture(event, payload);
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      console.warn(`[analytics] failed to capture ${event}`, error);
+    }
+  }
+}

--- a/src/lib/analytics/events.ts
+++ b/src/lib/analytics/events.ts
@@ -1,0 +1,57 @@
+// The buyer-funnel event contract, shared with silver.dev.
+//
+// silver.dev measures a buyer from a commercial page through to contact, but
+// the fees calculator lives here — so the middle of that funnel can only be
+// emitted by this app. The names below must match
+// `src/lib/analytics/events.ts` in silver-dev-org/website exactly: PostHog
+// funnels key off the strings, so a near-miss produces a silently broken
+// funnel rather than an error.
+//
+// Renaming a member breaks reporting. Add new ones instead.
+
+export enum AnalyticsEvent {
+  FEES_CALCULATOR_OPENED = "fees_calculator_opened",
+  FEES_CALCULATOR_COMPLETED = "fees_calculator_completed",
+  MEETING_BOOKING_STARTED = "meeting_booking_started",
+}
+
+export enum AnalyticsProperty {
+  PAGE_PATH = "page_path",
+  PAGE_TYPE = "page_type",
+  PAGE_TOPIC = "page_topic",
+  SOURCE = "source",
+  REFERRER = "referrer",
+  BOOKING_SURFACE = "booking_surface",
+  UTM_SOURCE = "utm_source",
+  UTM_MEDIUM = "utm_medium",
+  UTM_CAMPAIGN = "utm_campaign",
+  UTM_CONTENT = "utm_content",
+  UTM_TERM = "utm_term",
+}
+
+// Matches the vocabulary silver.dev uses for its own pages, extended with the
+// one value that only exists on this side.
+export enum PageType {
+  CALCULATOR = "calculator",
+}
+
+export enum BookingSurface {
+  LINK = "link",
+}
+
+// Query-string keys read off the landing URL, paired with the property they map
+// to. Anything not on this list is dropped — a URL can carry arbitrary params
+// and none of them should reach PostHog unreviewed.
+export const UTM_PARAMS: ReadonlyArray<
+  readonly [param: string, property: AnalyticsProperty]
+> = [
+  ["utm_source", AnalyticsProperty.UTM_SOURCE],
+  ["utm_medium", AnalyticsProperty.UTM_MEDIUM],
+  ["utm_campaign", AnalyticsProperty.UTM_CAMPAIGN],
+  ["utm_content", AnalyticsProperty.UTM_CONTENT],
+  ["utm_term", AnalyticsProperty.UTM_TERM],
+] as const;
+
+export type AnalyticsProperties = Partial<
+  Record<AnalyticsProperty, string | number | boolean>
+>;


### PR DESCRIPTION
Companion to [silver-dev-org/website#86](https://github.com/silver-dev-org/website/pull/86) — the open.silver.dev half of [GRO-5](https://linear.app/silverdev/issue/GRO-5/measure-buyer-actions-on-commercial-pages-with-posthog).

**Draft:** the completion definition below is a judgment call that needs a second opinion, and the funnel can't be confirmed until #86 is deployed.

## Why

silver.dev now measures a buyer from a commercial page through to contact. The fees calculator lives here, so the middle of that funnel is invisible to it — that side can see a visitor leave for the calculator and nothing after. GRO-5 names `fees_calculator_completed` explicitly and it can only be emitted from this repo.

## What

**`src/lib/analytics/`** — the same event and property names silver.dev uses. PostHog funnels key off the strings, so these must match exactly; a near-miss silently breaks the funnel rather than erroring. Plus a `captureEvent` wrapper that cannot throw into a click handler.

| Event | Fires when |
|---|---|
| `fees_calculator_opened` | The calculator mounts |
| `fees_calculator_completed` | A visitor first adjusts a term |
| `meeting_booking_started` | "Book with Gabriel" is clicked |

### On the completion definition

The calculator renders a number from its defaults the moment it loads, so "first computed result" would fire for every arrival and mean nothing. I've defined completion as **the first adjustment of any term** — the visitor put their own numbers in and read the estimate back. That's one call to `setContractProp`, fired once per mount.

The alternative reading is the terminal action (share/export). The `share()` function and its `fees_calculator_shared` event already exist but the button is commented out (`client.tsx`), so there's no live terminal action to hang it on. Happy to switch if you'd rather wait for that button to come back.

### Bonus: a gap closed

"Book with Gabriel" points at `silver.dev/companies`, a server redirect straight to Calendly with no client session in between. #86 documents that path as untrackable from the marketing side. Clicking it here is the last observable moment, so this adds a booking route that was previously absent from the funnel entirely.

## How the cross-domain join works

Both apps write the PostHog cookie to `.silver.dev` — posthog-js sets `cross_subdomain_cookie` true for any host except `herokuapp.com`/`vercel.app`/`netlify.app` — so these events land on the **same person** as the marketing funnel. No linking hack needed.

Three conditions, all currently met:
- Same PostHog project key ✅ (both read `NEXT_PUBLIC_POSTHOG_KEY`)
- `cross_subdomain_cookie` left at default ✅
- Cookie-backed persistence ✅

Attribution survives the hop too: #86 forwards `src` and the UTM keys when redirecting `/fees` here, and `captureEvent` reads them off the URL, so a buyer arriving from the quote receipt email stays attributed instead of landing as "direct".

⚠️ On a `*.vercel.app` preview the flag resolves to `false` and the join fails. Verify on real hostnames.

## Verification

`tsc --noEmit`, `next lint`, `next build` all clean. Walked in a real browser against `next dev`, arriving at `/fees-calculator?src=quote_receipt&utm_campaign=spring`:

| Check | Result |
|---|---|
| `fees_calculator_opened` on mount | one event |
| Attribution carried through | `source: "quote_receipt"`, `utm_campaign: "spring"` on every event |
| Page labelling | `page_type: "calculator"`, `page_topic: "fees_calculator"` |
| `fees_calculator_completed` once | one event across **two** separate input changes |
| `meeting_booking_started` | fired with `booking_surface: "link"` |
| Link hardening | `rel="noopener noreferrer"` present |
| No PII | no name, address, or free text in any payload |

Not yet verified: the joined funnel across both domains. That needs #86 in production and is the real acceptance criterion — until one person walks both domains in a single funnel, these are two datasets.

## Not touched

`fees_calculator_shared` and the commented-out share button are left exactly as they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8LrHXKBRsoWpcUgu9SqFr